### PR TITLE
Fix "Call to deprecated constant FILE_EXISTS_REPLACE"

### DIFF
--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -45,14 +45,14 @@ class SettingsForm extends ConfigFormBase
         $fileSystem = \Drupal::service('file_system');
 
         $directory = $fileSystemConfig->get('default_scheme') . '://cleverpush';
-        
+
         $options = FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS;
         $fileSystem->prepareDirectory($directory, $options);
 
         $filenameWorker = $directory . '/cleverpush-worker.js';
-        file_save_data('importScripts("https://static.cleverpush.com/channel/worker/' . $channelId . '.js");', $filenameWorker, FILE_EXISTS_REPLACE);
+        file_save_data('importScripts("https://static.cleverpush.com/channel/worker/' . $channelId . '.js");', $filenameWorker, FileSystemInterface::EXISTS_REPLACE);
         $filenameManifest = $directory . '/cleverpush-manifest.json';
-        file_save_data('{ "start_url": "/", "display": "standalone", "gcm_sender_id": "890396972010","gcm_user_visible_only": true }', $filenameManifest, FILE_EXISTS_REPLACE);
+        file_save_data('{ "start_url": "/", "display": "standalone", "gcm_sender_id": "890396972010","gcm_user_visible_only": true }', $filenameManifest, FileSystemInterface::EXISTS_REPLACE);
 
         $this->config('cleverpush.settings')
             ->set('channelId', $channelId)


### PR DESCRIPTION
Hi, I'm in the process of upgrading my site from Drupal 8 to Drupal 9.

Running the upgrade_status check, we get these deprecations, they are fixed in this PR.

```
$ drush upgrade_status:analyze cleverpush
 [notice] Processing /var/www/foodweb.local/releases/local/docroot/modules/contrib/cleverpush-drupal-plugin.

================================================================================
CleverPush, --
Scanned on Do., 12.08.2021 - 17:26

FILE: modules/contrib/cleverpush-drupal-plugin/src/Form/SettingsForm.php

STATUS         LINE                           MESSAGE
--------------------------------------------------------------------------------
Check manually 53   Call to deprecated constant FILE_EXISTS_REPLACE: Deprecated
                    in drupal:8.7.0 and is removed from drupal:9.0.0. Use
                    Drupal\Core\File\FileSystemInterface::EXISTS_REPLACE.
--------------------------------------------------------------------------------
Check manually 55   Call to deprecated constant FILE_EXISTS_REPLACE: Deprecated
                    in drupal:8.7.0 and is removed from drupal:9.0.0. Use
                    Drupal\Core\File\FileSystemInterface::EXISTS_REPLACE.
--------------------------------------------------------------------------------
```